### PR TITLE
Don't fail if pkg install indicates package already installed.

### DIFF
--- a/src/ensure.rs
+++ b/src/ensure.rs
@@ -730,7 +730,7 @@ where
         Err(e) => Err(e.into()),
         Ok(es) => {
             if !es.success() {
-                Err(anyhow!("exec {:?}: failed {:?}", &args, &es))
+                Err(anyhow!("exec {:?}: failed {:?}", &args, &es).context(es))
             } else {
                 Ok(())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1607,7 +1607,16 @@ fn pkg_install(
         newargs.push(pkg.as_ref());
     }
 
-    ensure::run(log, &newargs)
+    if let Err(e) = ensure::run(log, &newargs) {
+        let c = e.downcast_ref().map(std::process::ExitStatus::code).flatten();
+        if let Some(4) = c {
+            info!(log, "nothing to do -- package(s) already installed");
+        } else {
+            return Err(e);
+        }
+    }
+
+    Ok(())
 }
 
 fn pkg_uninstall(


### PR DESCRIPTION
Ran into a case of identical `pkg_install` steps that could be activated together depnding on what feature flags were passed. Whichever came first would succeed but the latter would fail because `pkg install` returns a non-zero exit status to indicate no changes were made, i.e., package is already installed.